### PR TITLE
Added argument for server play and fixed redifining lib/pref location

### DIFF
--- a/src/externs.h
+++ b/src/externs.h
@@ -940,6 +940,7 @@ extern errr get_rnd_line(cptr file_name, int entry, char *output);
 
 extern errr counts_write(int where, u32b count);
 extern u32b counts_read(int where);
+extern bool arg_lock_name; /*locks player name for server play --phantom*/
 
 /* flavor.c */
 extern void get_table_name_aux(char *out_string);

--- a/src/files.c
+++ b/src/files.c
@@ -18,6 +18,14 @@
 /* #undef _POSIX_SAVED_IDS */
 
 
+/*locks player name for server play
+ *this is only placed here, since including it in the other
+ *header files would interfere with the extern variable
+ *--phantom
+*/
+bool arg_lock_name;
+
+
 /*
  * Hack -- drop permissions
  */
@@ -5498,6 +5506,9 @@ void process_player_name(bool sf)
  * Unix machines?  XXX XXX
  *
  * What a horrible name for a global function.  XXX XXX XXX
+
+ * Added a check to see if this is for server play, if so, lock the player name
+ * -- phantom
  */
 void get_name(void)
 {
@@ -5506,25 +5517,30 @@ void get_name(void)
     /* Save the player name */
     strcpy(tmp, player_name);
 
-    /* Prompt for a new name */
-    if (get_string("Enter a name for your character: ", tmp, 15))
+    /*If the -l command was used, skip this section*/
+    /*--phantom*/
+    if(!arg_lock_name)
     {
-        /* Use the name */
-        strcpy(player_name, tmp);
-    }
+    	/* Prompt for a new name */
+    	if (get_string("Enter a name for your character: ", tmp, 15))
+    	{
+       	 /* Use the name */
+       	 strcpy(player_name, tmp);
+    	}
 
-    if (0 == strlen(player_name))
-    {
-        /* Use default name */
-        strcpy(player_name, "PLAYER");
-    }
+    	if (0 == strlen(player_name))
+   	 {
+       	 /* Use default name */
+       	 strcpy(player_name, "PLAYER");
+    	}
 
-    /* Re-Draw the name (in light blue) */
-    Term_erase(34, 1, 255);
-    c_put_str(TERM_L_BLUE, player_name, 1, 14);
+    	/* Re-Draw the name (in light blue) */
+    	Term_erase(34, 1, 255);
+   	 c_put_str(TERM_L_BLUE, player_name, 1, 14);
 
-    /* Erase the prompt, etc */
-    clear_from(22);
+    	/* Erase the prompt, etc */
+    	clear_from(22);
+     }
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -210,6 +210,15 @@ static void change_path(cptr info)
 			break;
 		}
 
+                /*added pref because it's missing*/
+		/*--phantom*/
+                case 'p':
+                {
+                        string_free(ANGBAND_DIR_PREF);
+                        ANGBAND_DIR_PREF = string_make(s+1);
+                        break;
+                }
+
 		case 'x':
 		{
 			string_free(ANGBAND_DIR_XTRA);
@@ -470,6 +479,15 @@ int main(int argc, char *argv[])
 			{
 				if (!argv[i][2]) goto usage;
 				strcpy(player_name, &argv[i][2]);
+				break;
+			}
+
+			/*locks player name for server play*/
+			/*--phantom*/
+			case 'l':
+			case 'L':
+			{
+				arg_lock_name = TRUE;
 				break;
 			}
 


### PR DESCRIPTION
Added a command line argument -l, which is used for server play, where the username should not be changed.
For redefining directory locations with -d, -dpref was missing, so it was fixed.