### PR TITLE
No selling improvements

### DIFF
--- a/src/object2.c
+++ b/src/object2.c
@@ -6347,8 +6347,7 @@ bool make_gold(object_type *j_ptr)
 
     if (no_selling)
     {
-        j_ptr->pval += j_ptr->pval / 2;
-        j_ptr->pval += j_ptr->pval * 2 * object_level / 100;
+        j_ptr->pval *= MAX(5, object_level / 5);
     }
 
     j_ptr->pval = j_ptr->pval * (625 - virtue_current(VIRTUE_SACRIFICE)) / 625;

--- a/src/store.c
+++ b/src/store.c
@@ -2260,14 +2260,9 @@ static void store_sell(void)
     if (cur_store_num == STORE_HOME)
         q = "Drop which item? ";
 
-    else if (cur_store_num == STORE_MUSEUM)
+    else if (cur_store_num == STORE_MUSEUM || no_selling)
         q = "Give which item? ";
 
-    else if (no_selling)
-    {
-        msg_print("Selling is prohibited!");
-        return;
-    }
     else
         q = "Sell which item? ";
 
@@ -2385,7 +2380,10 @@ static void store_sell(void)
             price = ot_ptr->max_cost;
         price *= q_ptr->number;
 
-        sprintf(prompt, "Really sell %s (%c) for <color:R>%d</color> gp? <color:y>[y/n]</color>", o_name, index_to_label(item), price);
+        if (!no_selling)
+            sprintf(prompt, "Really sell %s (%c) for <color:R>%d</color> gp? <color:y>[y/n]</color>", o_name, index_to_label(item), price);
+        else
+           sprintf(prompt, "Really give %s (%c)?", o_name, index_to_label(item));
         if (msg_prompt(prompt, "ny", PROMPT_YES_NO) == 'y')
         {
             if (cur_store_num == STORE_BLACK) /* The black market is illegal! */
@@ -2395,13 +2393,16 @@ static void store_sell(void)
                 virtue_add(VIRTUE_NATURE, 1);
 
             /* Get some money */
-            p_ptr->au += price;
-            p_ptr->redraw |= PR_GOLD;
-            if (prace_is_(RACE_MON_LEPRECHAUN))
-                p_ptr->update |= (PU_BONUS | PU_HP | PU_MANA);
+            if (!no_selling)
+            {
+                p_ptr->au += price;
+                p_ptr->redraw |= PR_GOLD;
+                if (prace_is_(RACE_MON_LEPRECHAUN))
+                    p_ptr->update |= (PU_BONUS | PU_HP | PU_MANA);
 
-            /* Update the display */
-            store_prt_gold();
+                /* Update the display */
+                store_prt_gold();
+            }
 
             /* Identify it */
             stats_on_sell(o_ptr); /* before identify, please! */
@@ -2424,7 +2425,10 @@ static void store_sell(void)
             object_desc(o_name, q_ptr, OD_COLOR_CODED);
 
             /* Describe the result (in message buffer) */
-            msg_format("You sold %s for <color:R>%d</color> gold.", o_name, price);
+            if (!no_selling)
+                msg_format("You sold %s for <color:R>%d</color> gold.", o_name, price);
+            else
+                msg_format("You gave %s.", o_name);
 
             /*
              * Hack -- Allocate charges between those wands or rods sold
@@ -3211,6 +3215,8 @@ void do_cmd_store(void)
             prt("p) Purchase an item", 21 + xtra_stock, 30);
             if (!no_selling)
                 prt("s) Sell an item", 22 + xtra_stock, 30);
+            else
+                prt("s) Give an item", 22 + xtra_stock, 30);
             prt("x) eXamine an item", 23 + xtra_stock,30);
             if (rogue_like_commands) /* P -> b coincidentally and 'P'urchase entire stock works */
                 prt("  P) Purchase entire stock", 23 + xtra_stock, 56);


### PR DESCRIPTION
Increases the bonus gold from no_selling such that it's fairly noticeable (if perhaps still not comparable to the normal income from selling) and scales as you get deeper into the dungeon. Also enables the early-game convenience of donating items to identify them.