### PR TITLE
Fix rune-selling exploit.

### DIFF
--- a/src/rune_knight.c
+++ b/src/rune_knight.c
@@ -129,6 +129,10 @@ bool rune_add(object_type *o_ptr, int which, bool prompt)    /* Birthing needs a
                 format("Really add %^s to %^s?", 
                     rune_desc(which), o_name))) return FALSE;
     }
+    if (object_is_nameless(o_ptr))
+    {
+            o_ptr->discount = 99;
+    }
 
     o_ptr->rune = which;
 


### PR DESCRIPTION
This fix removes the exploit by which a rune knight player (preferably android for maximum efficiency) could rapidly multiply their gold to the point of buying out shops to generate artifacts by slapping runes on stacks of items and selling them back to the shop (for instance, buying large quantities of robes, leather armours, or cloaks).