### PR TITLE
Added askfor_file function to restrict server play

### DIFF
--- a/src/cmd4.c
+++ b/src/cmd4.c
@@ -1839,7 +1839,7 @@ void do_cmd_macros(void)
             sprintf(tmp, "%s.prf", player_base);
 
             /* Ask for a file */
-            if (!askfor(tmp, 80)) continue;
+            if (!askfor_file(tmp, 80, TRUE)) continue;
 
             /* Process the given filename */
             err = process_pref_file(tmp);
@@ -1875,7 +1875,7 @@ void do_cmd_macros(void)
             sprintf(tmp, "%s.prf", player_base);
 
             /* Ask for a file */
-            if (!askfor(tmp, 80)) continue;
+            if (!askfor_file(tmp, 80, TRUE)) continue;
 
             /* Dump the macros */
             (void)macro_dump(tmp);
@@ -1958,7 +1958,7 @@ void do_cmd_macros(void)
             ascii_to_text(tmp, macro__buf);
 
             /* Get an encoded action */
-            if (askfor(tmp, 80))
+            if (askfor_file(tmp, 80, TRUE))
             {
                 /* Convert to ascii */
                 text_to_ascii(macro__buf, tmp);
@@ -2008,8 +2008,12 @@ void do_cmd_macros(void)
             /* Default filename */
             sprintf(tmp, "%s.prf", player_base);
 
-            /* Ask for a file */
-            if (!askfor(tmp, 80)) continue;
+            /*Do not allow users in server mode to write to arbitrary files*/
+            if(!arg_lock_name)
+            {
+                /* Ask for a file */
+                if (!askfor_file(tmp, 80, TRUE)) continue;
+            }
 
             /* Dump the macros */
             (void)keymap_dump(tmp);
@@ -2287,7 +2291,7 @@ void do_cmd_visuals(void)
             sprintf(tmp, "%s.prf", player_base);
 
             /* Query */
-            if (!askfor(tmp, 70)) continue;
+            if (!askfor_file(tmp, 70, TRUE)) continue;
 
             /* Process the given filename */
             (void)process_pref_file(tmp);
@@ -2312,7 +2316,7 @@ void do_cmd_visuals(void)
             sprintf(tmp, "%s.prf", player_base);
 
             /* Get a filename */
-            if (!askfor(tmp, 70)) continue;
+            if (!askfor_file(tmp, 70, TRUE)) continue;
 
             /* Build the filename */
             path_build(buf, sizeof(buf), ANGBAND_DIR_USER, tmp);
@@ -2363,7 +2367,7 @@ void do_cmd_visuals(void)
             sprintf(tmp, "%s.prf", player_base);
 
             /* Get a filename */
-            if (!askfor(tmp, 70)) continue;
+            if (!askfor_file(tmp, 70, TRUE)) continue;
 
             /* Build the filename */
             path_build(buf, sizeof(buf), ANGBAND_DIR_USER, tmp);
@@ -2432,7 +2436,7 @@ void do_cmd_visuals(void)
             sprintf(tmp, "%s.prf", player_base);
 
             /* Get a filename */
-            if (!askfor(tmp, 70)) continue;
+            if (!askfor_file(tmp, 70, TRUE)) continue;
 
             /* Build the filename */
             path_build(buf, sizeof(buf), ANGBAND_DIR_USER, tmp);
@@ -2878,7 +2882,7 @@ void do_cmd_colors(void)
             sprintf(tmp, "%s.prf", player_base);
 
             /* Query */
-            if (!askfor(tmp, 70)) continue;
+            if (!askfor_file(tmp, 70, TRUE)) continue;
 
             /* Process the given filename */
             (void)process_pref_file(tmp);
@@ -2909,7 +2913,7 @@ void do_cmd_colors(void)
             sprintf(tmp, "%s.prf", player_base);
 
             /* Get a filename */
-            if (!askfor(tmp, 70)) continue;
+            if (!askfor_file(tmp, 70, TRUE)) continue;
 
             /* Build the filename */
             path_build(buf, sizeof(buf), ANGBAND_DIR_USER, tmp);

--- a/src/externs.h
+++ b/src/externs.h
@@ -1573,6 +1573,7 @@ extern void c_roff(byte attr, cptr str);
 extern void roff(cptr str);
 extern void clear_from(int row);
 extern bool askfor_aux(char *buf, int len, bool numpad_cursor);
+extern bool askfor_file(char *buf, int len, bool numpad_cursor);
 extern bool askfor(char *buf, int len);
 extern bool get_string(cptr prompt, char *buf, int len);
 extern bool get_check(cptr prompt);


### PR DESCRIPTION
Currently, character dumps can overwrite other files, as can macros if they are enabled. Not only can they overwrite files in the current directory, it can overwrite in other directories. "\" and "." are permitted characters.

I added an askfor_file function, to restrict the usage when playing on a shared server (using the -l ) argument. It currently checks for arg_lock_name, and if true, it only allows to write to the default user file, which is based on the player's name.

Character dumps have a default filename, which includes the character name, and time.